### PR TITLE
Stop error being thrown if there was no matches in file

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ module.exports = function (options) {
 			content = file.contents.toString();
 			matches = content.match(term);
 
-			matches.forEach(options.fn);
+			if(matches !== null)
+				matches.forEach(options.fn);
 		}
 		catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-scan', err));

--- a/index.js
+++ b/index.js
@@ -42,8 +42,9 @@ module.exports = function (options) {
 			content = file.contents.toString();
 			matches = content.match(term);
 
-			if(matches !== null)
+			if(matches !== null) {
 				matches.forEach(options.fn);
+			}
 		}
 		catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-scan', err));


### PR DESCRIPTION
This stops gulp from throwing an error and exiting if a file contains 0 matches:

```
[18:19:05] Using gulpfile ~/Repositories/app/Gulpfile.js
[18:19:05] Starting 'default'...
[18:19:05] 'default' errored after 153 ms
[18:19:05] TypeError in plugin 'gulp-scan'
Message:
    Cannot read property 'forEach' of null
```
