### PR TITLE
Pass through scanned files into pipe

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,6 @@ module.exports = function (options) {
 			this.emit('error', new gutil.PluginError('gulp-scan', err));
 		}
 
-		cb();
+		cb(null, file);
 	});
 };


### PR DESCRIPTION
Hi, thank you for a nice gulp plugin!

I'm using gulp-scan for scanning any unwanted content for output by raising errors in `fn`. However, I've noticed that gulp-scan never passes scanned files through into pipe, so following gulp plugins like `gulp.dest` do nothing.

This PR is just a tiny fix for passing files thorugh after scanning them.

Thanks!
